### PR TITLE
Pin Docker images to specific tags and fix node-exporter incompatibility

### DIFF
--- a/docker-compose.exporters.yml
+++ b/docker-compose.exporters.yml
@@ -10,9 +10,9 @@ services:
       - /sys:/host/sys:ro
       - /:/rootfs:ro
     command:
-      - '-collector.procfs=/host/proc'
-      - '-collector.sysfs=/host/sys'
-      - '-collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)'
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)'
     restart: unless-stopped
     ports:
       - 9100:9100

--- a/docker-compose.exporters.yml
+++ b/docker-compose.exporters.yml
@@ -3,7 +3,7 @@ version: '2.1'
 services:
 
   nodeexporter:
-    image: prom/node-exporter
+    image: prom/node-exporter:v0.15.0
     container_name: nodeexporter
     volumes:
       - /proc:/host/proc:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,9 +56,9 @@ services:
       - /sys:/host/sys:ro
       - /:/rootfs:ro
     command:
-      - '-collector.procfs=/host/proc'
-      - '-collector.sysfs=/host/sys'
-      - '-collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)'
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)'
     restart: unless-stopped
     expose:
       - 9100

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ volumes:
 services:
 
   prometheus:
-    image: prom/prometheus
+    image: prom/prometheus:v1.8.0
     container_name: prometheus
     volumes:
       - ./prometheus/:/etc/prometheus/
@@ -49,7 +49,7 @@ services:
       org.label-schema.group: "monitoring"
 
   nodeexporter:
-    image: prom/node-exporter
+    image: prom/node-exporter:v0.15.0
     container_name: nodeexporter
     volumes:
       - /proc:/host/proc:ro


### PR DESCRIPTION
See #26:

We are not guaranteed with compatible command line syntax with the latest node-exporter version.