### PR TITLE
added line to enable Lifecycle APIs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - '--web.console.libraries=/etc/prometheus/console_libraries'
       - '--web.console.templates=/etc/prometheus/consoles'
       - '--storage.tsdb.retention=200h'
+      - '--web.enable-lifecycle'
     # restart: unless-stopped
     expose:
       - 9090


### PR DESCRIPTION
The --web.enable-lifecycle flag controls HTTP reloads and shutdowns in
Prometheus. Disabled by default in v2.0