### PR TITLE
Grafana 4.6.2 -> 4.6.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       org.label-schema.group: "monitoring"
   
   grafana:
-    image: grafana/grafana:4.6.2
+    image: grafana/grafana:4.6.3
     container_name: grafana
     volumes:
       - grafana_data:/var/lib/grafana


### PR DESCRIPTION
Turns out 4.6.3 is the latest release version https://github.com/grafana/grafana/blob/master/CHANGELOG.md