### PR TITLE
Alerting rules update

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -9,9 +9,7 @@ global:
 
 # Load and evaluate rules in this file every 'evaluation_interval' seconds.
 rule_files:
-  - "targets.rules"
-  - "host.rules"
-  - "containers.rules"
+  - "alert.rules"
 
 # A scrape configuration containing exactly one endpoint to scrape.
 scrape_configs:


### PR DESCRIPTION
Seems these three rule alert files were merged into `alert.rules`, updated `prometheus.yml` to reflect this. `README.md` references the three missing rule alert files and should be updated as well.