### PR TITLE
Add Prometheus Pushgateway to the docker-compose infrastructure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Prerequisites:
 Containers:
 
 * Prometheus (metrics database) `http://<host-ip>:9090`
+* Prometheus-Pushgateway (push acceptor for ephemeral and batch jobs) `http://<host-ip>:9091`
 * AlertManager (alerts management) `http://<host-ip>:9093`
 * Grafana (visualize metrics) `http://<host-ip>:3000`
 * NodeExporter (host metrics collector)
@@ -253,3 +254,13 @@ receivers:
 ```
 
 ![Slack Notifications](https://raw.githubusercontent.com/stefanprodan/dockprom/master/screens/Slack_Notifications.png)
+
+## Sending metrics to the Pushgateway
+
+The [pushgateway](https://github.com/prometheus/pushgateway) is used to collect data from batch jobs or from services.
+ 
+To push data, simply execute:
+
+    echo "some_metric 3.14" | curl --data-binary @- http://user:password@localhost:9091/metrics/job/some_job
+
+Please replace the `user:password` part with your user and password set in the initial configuration (default: `admin:admin`).

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -18,6 +18,16 @@
     tls off
 }
 
+:9091 {
+    basicauth / {$ADMIN_USER} {$ADMIN_PASSWORD}
+    proxy / pushgateway:9091 {
+            transparent
+        }
+
+    errors stderr
+    tls off
+}
+
 :3000 {
     proxy / grafana:3000 {
             transparent

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,17 @@ services:
     labels:
       org.label-schema.group: "monitoring"
 
+  pushgateway:
+    image: prom/pushgateway
+    container_name: pushgateway
+    restart: unless-stopped
+    expose:
+      - 9091
+    networks:
+      - monitor-net
+    labels:
+      org.label-schema.group: "monitoring"
+
   caddy:
     image: stefanprodan/caddy
     container_name: caddy
@@ -113,6 +124,7 @@ services:
       - "3000:3000"
       - "9090:9090"
       - "9093:9093"
+      - "9091:9091"
     volumes:
       - ./caddy/:/etc/caddy/
     environment:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -28,6 +28,13 @@ scrape_configs:
     static_configs:
       - targets: ['localhost:9090']
 
+  - job_name: 'pushgateway'
+    scrape_interval: 10s
+    honor_labels: true
+    static_configs:
+      - targets: ['pushgateway:9091']
+
+
 alerting:
   alertmanagers:
   - scheme: http


### PR DESCRIPTION
This adds the Prometheus Pushgateway (https://github.com/prometheus/pushgateway) to the example, so that you can publish metrics to the prometheus DB by simply running

`echo "some_metric 3.14" | curl --data-binary @- http://user:password@localhost:9091/metrics/job/some_job` in your host machine.