### PR TITLE
Update to latest releases and fix permission issue on initial dashboard creation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ volumes:
 services:
 
   prometheus:
-    image: prom/prometheus:v2.3.2
+    image: prom/prometheus:v2.4.2
     container_name: prometheus
     volumes:
       - ./prometheus/:/etc/prometheus/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       org.label-schema.group: "monitoring"
   
   grafana:
-    image: grafana/grafana:5.2.2
+    image: grafana/grafana:5.2.4
     container_name: grafana
     volumes:
       - grafana_data:/var/lib/grafana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       org.label-schema.group: "monitoring"
   
   alertmanager:
-    image: prom/alertmanager:v0.15.1
+    image: prom/alertmanager:v0.15.2
     container_name: alertmanager
     volumes: 
       - ./alertmanager/:/etc/alertmanager/

--- a/grafana/dashboards/docker_containers.json
+++ b/grafana/dashboards/docker_containers.json
@@ -1,4 +1,4 @@
-{
+{"dashboard": {
   "id": null,
   "title": "Docker Containers",
   "description": "Containers metrics",
@@ -1267,4 +1267,4 @@
   "version": 8,
   "links": [],
   "gnetId": null
-}
+}}

--- a/grafana/dashboards/docker_host.json
+++ b/grafana/dashboards/docker_host.json
@@ -1,4 +1,4 @@
-{
+{"dashboard": {
   "id": null,
   "title": "Docker Host",
   "description": "Docker host metrics",
@@ -1438,4 +1438,4 @@
   "version": 2,
   "links": [],
   "gnetId": null
-}
+}}

--- a/grafana/dashboards/monitor_services.json
+++ b/grafana/dashboards/monitor_services.json
@@ -1,4 +1,4 @@
-{
+{"dashboard": {
   "id": null,
   "title": "Monitor Services",
   "tags": [
@@ -1299,4 +1299,4 @@
   "version": 21,
   "links": [],
   "gnetId": null
-}
+}}

--- a/grafana/dashboards/nginx_container.json
+++ b/grafana/dashboards/nginx_container.json
@@ -1,4 +1,4 @@
-{
+{"dashboard": {
   "id": null,
   "title": "Nginx",
   "description": "Nginx exporter metrics",
@@ -395,4 +395,4 @@
   "version": 9,
   "links": [],
   "gnetId": null
-}
+}}

--- a/grafana/setup.sh
+++ b/grafana/setup.sh
@@ -60,15 +60,12 @@ install_dashboards() {
     if [[ -f "${dashboard}" ]]; then
       echo "Installing dashboard ${dashboard}"
 
-      echo "{\"dashboard\": `cat $dashboard`}" > "${dashboard}.wrapped"
-
-      if grafana_api POST /api/dashboards/db "" "${dashboard}.wrapped"; then
+      if grafana_api POST /api/dashboards/db "" "${dashboard}"; then
         echo "installed ok"
       else
         echo "install failed"
       fi
 
-      rm "${dashboard}.wrapped"
     fi
   done
 }


### PR DESCRIPTION
This pull request updates the following software:
- Prometheus to v2.4.2
- Alertmanager to v0.15.2
- Grafana to v5.2.4

There was also an issue with permissions on initial dashboard creation due to the changes in Grafana >= v5.1.

Resolves #69 and fixes #94.