### PR TITLE
Update cAdvisor, Prometheus and Grafana to latest versions

### DIFF
--- a/docker-compose.exporters.yml
+++ b/docker-compose.exporters.yml
@@ -23,7 +23,7 @@ services:
       org.label-schema.group: "monitoring"
 
   cadvisor:
-    image: google/cadvisor:v0.28.3
+    image: google/cadvisor:v0.31.0
     container_name: cadvisor
     volumes:
       - /:/rootfs:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       org.label-schema.group: "monitoring"
   
   grafana:
-    image: grafana/grafana:5.2.4
+    image: grafana/grafana:5.3.1
     container_name: grafana
     volumes:
       - grafana_data:/var/lib/grafana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ volumes:
 services:
 
   prometheus:
-    image: prom/prometheus:v2.4.2
+    image: prom/prometheus:v2.4.3
     container_name: prometheus
     volumes:
       - ./prometheus/:/etc/prometheus/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       org.label-schema.group: "monitoring"
 
   cadvisor:
-    image: google/cadvisor:v0.28.3
+    image: google/cadvisor:v0.31.0
     container_name: cadvisor
     volumes:
       - /:/rootfs:ro


### PR DESCRIPTION
This pull request updates the following software:
- cAdvisor to v0.31.0
- Prometheus to v2.4.3
- Grafana to v5.3.1