### PR TITLE
Update node_exporter to v0.17.0

### DIFF
--- a/docker-compose.exporters.yml
+++ b/docker-compose.exporters.yml
@@ -3,7 +3,7 @@ version: '2.1'
 services:
 
   nodeexporter:
-    image: prom/node-exporter:v0.16.0
+    image: prom/node-exporter:v0.17.0
     container_name: nodeexporter
     user: root
     privileged: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       org.label-schema.group: "monitoring"
 
   nodeexporter:
-    image: prom/node-exporter:v0.16.0
+    image: prom/node-exporter:v0.17.0
     container_name: nodeexporter
     user: root
     privileged: true


### PR DESCRIPTION
This pull request updates the following software:
- node_exporter to v0.17.0

This fixes the diskstats collector for kernel >4.19.