### PR TITLE
Updated to Grafana 6.0.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       org.label-schema.group: "monitoring"
 
   grafana:
-    image: grafana/grafana:5.4.3
+    image: grafana/grafana:6.0.0
     container_name: grafana
     volumes:
       - grafana_data:/var/lib/grafana


### PR DESCRIPTION
Updated to Grafana version 6.0.0.

http://docs.grafana.org/guides/whats-new-in-v6-0/