### PR TITLE
fixing exporters

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       org.label-schema.group: "monitoring"
 
   grafana:
-    image: grafana/grafana:6.0.2
+    image: grafana/grafana:6.1.0
     container_name: grafana
     volumes:
       - grafana_data:/var/lib/grafana


### PR DESCRIPTION
Port mapping is incompatible with network_mode: host
reference: docker/compose#4799 (comment)

Also cAdvisor must be privileged too (tested in Ubuntu 16, 18)