### PR TITLE
Fixes issues reported on cAdvisor logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,10 @@ services:
       - /sys:/sys:ro
       - /var/lib/docker:/var/lib/docker:ro
       #- /cgroup:/cgroup:ro #doesn't work on MacOS only for Linux
+      - /etc/machine-id:/etc/machine-id:ro
+      - /var/lib/dbus/machine-id:/var/lib/dbus/machine-id:ro
+    devices:
+      - /dev/kmsg:/dev/kmsg
     restart: unless-stopped
     expose:
       - 8080


### PR DESCRIPTION
Fixes the following issues reported on the cAdvisor logs:

1. `Failed to get system UUID: open /etc/machine-id: no such file or directory`
2. `Could not configure a source for OOM detection, disabling OOM events: open /dev/kmsg: no such file or directory`