### PR TITLE
 Update grafana to v8.0.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       org.label-schema.group: "monitoring"
 
   grafana:
-    image: grafana/grafana:8.0.0
+    image: grafana/grafana:8.0.2
     container_name: grafana
     volumes:
       - grafana_data:/var/lib/grafana


### PR DESCRIPTION
- [8.0.2 (2021-06-14)](https://github.com/grafana/grafana/releases/tag/v8.0.2)