### PR TITLE
Update docker-compose.exporters.yml : fix for `OOM detection, disabling OOM events`

### DIFF
--- a/docker-compose.exporters.yml
+++ b/docker-compose.exporters.yml
@@ -32,5 +32,5 @@ services:
     network_mode: host
     labels:
       org.label-schema.group: "monitoring"
-  
-
+    devices:
+      - /dev/kmsg:/dev/kmsg


### PR DESCRIPTION
fix for `Could not configure a source for OOM detection, disabling OOM events: open /dev/kmsg: no such file or directory` error message 
https://github.com/vegasbrianc/prometheus/issues/126#issuecomment-770937533