### PR TITLE
update node-exporter 1.2.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       org.label-schema.group: "monitoring"
 
   nodeexporter:
-    image: prom/node-exporter:v1.1.2
+    image: prom/node-exporter:v1.2.0
     container_name: nodeexporter
     volumes:
       - /proc:/host/proc:ro
@@ -58,7 +58,7 @@ services:
       - '--path.procfs=/host/proc'
       - '--path.rootfs=/rootfs'
       - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
     restart: unless-stopped
     expose:
       - 9100


### PR DESCRIPTION
NOTE: Filesystem collector flags have been renamed. --collector.filesystem.ignored-mount-points is now --collector.filesystem.mount-points-exclude