### PR TITLE
Revert "build(deps): update prometheus to v2.31.2"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ volumes:
 services:
 
   prometheus:
-    image: prom/prometheus:v2.31.2
+    image: prom/prometheus:v2.31.1
     container_name: prometheus
     volumes:
       - ./prometheus:/etc/prometheus


### PR DESCRIPTION
This reverts commit 05238b1167bd83325f55a82b86abad10f2c88ac4.

Prometheus currently doesn't have a version v.2.31.2 available, which is causing issue when pulling images. 

https://github.com/prometheus/prometheus/releases