### PR TITLE
Cadvisor high cpu fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,9 @@ services:
       - /sys:/sys:ro
       - /var/lib/docker:/var/lib/docker:ro
       #- /cgroup:/cgroup:ro #doesn't work on MacOS only for Linux
+    command:
+      - '-housekeeping_interval=10s'
+      - '-docker_only=true'
     restart: unless-stopped
     expose:
       - 8080

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -19,7 +19,7 @@ scrape_configs:
       - targets: ['nodeexporter:9100']
 
   - job_name: 'cadvisor'
-    scrape_interval: 5s
+    scrape_interval: 15s
     static_configs:
       - targets: ['cadvisor:8080']
 


### PR DESCRIPTION
If I am not mistaken, those settings won't affect the current dashboards at all, while reducing CPU usage of cadvisor by a lot. On my test system, the average CPU usage was reduced from ~13% to ~0.9%.

All the credit goes to this comment: https://github.com/google/cadvisor/issues/2523#issuecomment-785094428 

Thank you for the great project!