### PR TITLE
Add CVS stability recording rules and dashboard

### DIFF
--- a/grafana/provisioning/dashboards/cvs_stability_metrics.json
+++ b/grafana/provisioning/dashboards/cvs_stability_metrics.json
@@ -1,0 +1,429 @@
+{
+  "__inputs": [],
+  "__requires": [
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" }
+  ],
+  "uid": "cvs-stability-metrics",
+  "title": "CVS Stability Metrics",
+  "description": "Monitor swimmer count validity, pipeline crashes, and algo container exceptions",
+  "tags": ["cvs", "stability", "algo"],
+  "timezone": "browser",
+  "editable": true,
+  "refresh": "1h",
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "under_maintenance",
+        "type": "query",
+        "label": "Under Maintenance",
+        "description": "Filters non-operational pools (label on swimmer_count, no join needed). Validity and incident panels also join on cvs_maintenance_mode metric to exclude nightly clean restarts.",
+        "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+        "definition": "label_values(swimmer_count,under_maintenance)",
+        "query": { "query": "label_values(swimmer_count,under_maintenance)", "refId": "StandardVariableQuery" },
+        "refresh": 1,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": { "selected": true, "text": ["False"], "value": ["False"] }
+      },
+      {
+        "name": "pool_state",
+        "type": "query",
+        "label": "Pool State",
+        "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+        "definition": "label_values(swimmer_count{under_maintenance=~\"$under_maintenance\"},pool_state)",
+        "query": { "query": "label_values(swimmer_count{under_maintenance=~\"$under_maintenance\"},pool_state)", "refId": "StandardVariableQuery" },
+        "refresh": 1,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": { "selected": true, "text": ["LIVE", "SOFT_LAUNCH"], "value": ["LIVE", "SOFT_LAUNCH"] }
+      },
+      {
+        "name": "deploy_group",
+        "type": "query",
+        "label": "Deploy Group",
+        "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+        "definition": "label_values(swimmer_count{pool_state=~\"$pool_state\"},group)",
+        "query": { "query": "label_values(swimmer_count{pool_state=~\"$pool_state\"},group)", "refId": "StandardVariableQuery" },
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": { "selected": true, "text": ["All"], "value": ["$__all"] }
+      },
+      {
+        "name": "server",
+        "type": "query",
+        "label": "Server",
+        "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+        "definition": "label_values(swimmer_count{pool_state=~\"$pool_state\", group=~\"$deploy_group\"},environment)",
+        "query": { "query": "label_values(swimmer_count{pool_state=~\"$pool_state\", group=~\"$deploy_group\"},environment)", "refId": "StandardVariableQuery" },
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": { "selected": true, "text": ["All"], "value": ["$__all"] }
+      },
+      {
+        "name": "site_name",
+        "type": "query",
+        "label": "Site",
+        "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+        "definition": "label_values(swimmer_count{pool_state=~\"$pool_state\", environment=~\"$server\", group=~\"$deploy_group\"},site_name)",
+        "query": { "query": "label_values(swimmer_count{pool_state=~\"$pool_state\", environment=~\"$server\", group=~\"$deploy_group\"},site_name)", "refId": "StandardVariableQuery" },
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": { "selected": true, "text": ["All"], "value": ["$__all"] }
+      },
+      {
+        "name": "pool_name",
+        "type": "query",
+        "label": "Pool",
+        "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+        "definition": "label_values(swimmer_count{pool_state=~\"$pool_state\", environment=~\"$server\", group=~\"$deploy_group\", site_name=~\"$site_name\"},pool_name)",
+        "query": { "query": "label_values(swimmer_count{pool_state=~\"$pool_state\", environment=~\"$server\", group=~\"$deploy_group\", site_name=~\"$site_name\"},pool_name)", "refId": "StandardVariableQuery" },
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": { "selected": true, "text": ["All"], "value": ["$__all"] }
+      },
+      {
+        "name": "subquery_step",
+        "type": "interval",
+        "label": "Subquery Step",
+        "hide": 2,
+        "auto": true,
+        "auto_count": 720,
+        "auto_min": "5m",
+        "query": "5m,10m,15m,30m,1h",
+        "current": { "selected": true, "text": "auto", "value": "$__auto_interval_subquery_step" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Swimmer Count Validity",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false
+    },
+    {
+      "id": 3,
+      "type": "bargauge",
+      "title": "% Time with Valid Swimmer Count (per pool)",
+      "description": "Percentage of time each pool had a valid swimmer count over the selected time range. Lower = less stable.",
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 1 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "avg(avg_over_time(cvs:swimmer_valid:bool{environment=~\"$server\", site_name=~\"$site_name\", pool_name=~\"$pool_name\", pool_state=~\"$pool_state\", group=~\"$deploy_group\", under_maintenance=~\"$under_maintenance\"}[$__range]) * 100)",
+          "legendFormat": "OVERALL AVERAGE",
+          "instant": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sort(avg_over_time(cvs:swimmer_valid:bool{environment=~\"$server\", site_name=~\"$site_name\", pool_name=~\"$pool_name\", pool_state=~\"$pool_state\", group=~\"$deploy_group\", under_maintenance=~\"$under_maintenance\"}[$__range]) * 100)",
+          "legendFormat": "{{site_name}} / {{pool_name}}",
+          "instant": true,
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "continuous-RdYlGr" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 80 },
+              { "color": "green", "value": 95 }
+            ]
+          },
+          "unit": "percent",
+          "decimals": 1,
+          "min": 0,
+          "max": 100
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "OVERALL AVERAGE" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "white" } }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showUnfilled": true,
+        "minVizWidth": 8,
+        "minVizHeight": 16
+      }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Daily Trend: Validity % (overall avg)",
+      "description": "Daily overall average of swimmer count validity percentage.",
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 1 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "avg(avg_over_time(cvs:swimmer_valid:bool{environment=~\"$server\", site_name=~\"$site_name\", pool_name=~\"$pool_name\", pool_state=~\"$pool_state\", group=~\"$deploy_group\", under_maintenance=~\"$under_maintenance\"}[1d]) * 100)",
+          "legendFormat": "Validity %",
+          "range": true,
+          "interval": "1d",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "green" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 8,
+            "showPoints": "always",
+            "lineInterpolation": "linear"
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true, "calcs": ["mean", "lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "id": 5,
+      "type": "row",
+      "title": "Invalid Swimmer Count Incidents",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 11 },
+      "collapsed": false
+    },
+    {
+      "id": 6,
+      "type": "bargauge",
+      "title": "Estimated Incidents (per pool)",
+      "description": "Estimated number of times each pool transitioned to invalid swimmer count over the selected range. Excludes non-operational pools (under_maintenance) and nightly clean restarts (cvs_maintenance_mode).",
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "avg(ceil(changes(cvs:swimmer_incident:bool{environment=~\"$server\", site_name=~\"$site_name\", pool_name=~\"$pool_name\", pool_state=~\"$pool_state\", group=~\"$deploy_group\", under_maintenance=~\"$under_maintenance\"}[$__range]) / 2))",
+          "legendFormat": "OVERALL AVERAGE",
+          "instant": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sort_desc(ceil(changes(cvs:swimmer_incident:bool{environment=~\"$server\", site_name=~\"$site_name\", pool_name=~\"$pool_name\", pool_state=~\"$pool_state\", group=~\"$deploy_group\", under_maintenance=~\"$under_maintenance\"}[$__range]) / 2))",
+          "legendFormat": "{{site_name}} / {{pool_name}}",
+          "instant": true,
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "continuous-BlYlRd" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 50 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "OVERALL AVERAGE" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "white" } }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showUnfilled": true
+      }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Daily Trend: Avg Incidents per Pool (overall avg)",
+      "description": "Daily overall average of invalid swimmer count incidents per pool. Excludes non-operational pools (under_maintenance) and nightly clean restarts (cvs_maintenance_mode).",
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "avg(ceil(changes(cvs:swimmer_incident:bool{environment=~\"$server\", site_name=~\"$site_name\", pool_name=~\"$pool_name\", pool_state=~\"$pool_state\", group=~\"$deploy_group\", under_maintenance=~\"$under_maintenance\"}[1d]) / 2))",
+          "legendFormat": "Incidents",
+          "range": true,
+          "interval": "1d",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "orange" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 8,
+            "showPoints": "always",
+            "lineInterpolation": "linear"
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true, "calcs": ["mean", "lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "id": 8,
+      "type": "row",
+      "title": "Algo Container Exceptions",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 20 },
+      "collapsed": false
+    },
+    {
+      "id": 11,
+      "type": "barchart",
+      "title": "Avg Exceptions per Pool by Algo Container",
+      "description": "Average exception count per pool, grouped by algo container. Shows the mean across all matching pools.",
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 21 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "(avg by (service) (cvs_exc_per_service{environment=~\"$server\", site_name=~\"$site_name\", pool_name=~\"$pool_name\", group=~\"$deploy_group\", exception_name!~\"NoneType|KeyboardInterrupt\", service=\"Detection\"} and on(pool_name, site_name, environment) swimmer_count{environment=~\"$server\", pool_state=~\"$pool_state\", group=~\"$deploy_group\", under_maintenance=~\"$under_maintenance\"}) or label_replace(vector(0), \"service\", \"Detection\", \"\", \"\")) or (avg by (service) (cvs_exc_per_service{environment=~\"$server\", site_name=~\"$site_name\", pool_name=~\"$pool_name\", group=~\"$deploy_group\", exception_name!~\"NoneType|KeyboardInterrupt\", service=\"Ctm\"} and on(pool_name, site_name, environment) swimmer_count{environment=~\"$server\", pool_state=~\"$pool_state\", group=~\"$deploy_group\", under_maintenance=~\"$under_maintenance\"}) or label_replace(vector(0), \"service\", \"Ctm\", \"\", \"\")) or (avg by (service) (cvs_exc_per_service{environment=~\"$server\", site_name=~\"$site_name\", pool_name=~\"$pool_name\", group=~\"$deploy_group\", exception_name!~\"NoneType|KeyboardInterrupt\", service=\"Gtm\"} and on(pool_name, site_name, environment) swimmer_count{environment=~\"$server\", pool_state=~\"$pool_state\", group=~\"$deploy_group\", under_maintenance=~\"$under_maintenance\"}) or label_replace(vector(0), \"service\", \"Gtm\", \"\", \"\")) or (avg by (service) (cvs_exc_per_service{environment=~\"$server\", site_name=~\"$site_name\", pool_name=~\"$pool_name\", group=~\"$deploy_group\", exception_name!~\"NoneType|KeyboardInterrupt\", service=\"DecisionEngine\"} and on(pool_name, site_name, environment) swimmer_count{environment=~\"$server\", pool_state=~\"$pool_state\", group=~\"$deploy_group\", under_maintenance=~\"$under_maintenance\"}) or label_replace(vector(0), \"service\", \"DecisionEngine\", \"\", \"\"))",
+          "legendFormat": "{{service}}",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "Time" }, "properties": [{ "id": "custom.hideFrom", "value": { "legend": true, "tooltip": true, "viz": true } }] }
+        ]
+      },
+      "options": { "orientation": "horizontal", "showValue": "always", "barWidth": 0.8, "groupWidth": 0.7 }
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Daily Trend: Avg Exceptions per Pool by Container",
+      "description": "Daily overall average of algo container exception counts per pool, grouped by service.",
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 21 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "avg_over_time((avg by (service) (cvs_exc_per_service{environment=~\"$server\", site_name=~\"$site_name\", pool_name=~\"$pool_name\", group=~\"$deploy_group\", exception_name!~\"NoneType|KeyboardInterrupt\", service=~\"Detection|Ctm|Gtm|DecisionEngine\"} and on(pool_name, site_name, environment) swimmer_count{environment=~\"$server\", pool_state=~\"$pool_state\", group=~\"$deploy_group\", under_maintenance=~\"$under_maintenance\"}))[1d:30m])",
+          "legendFormat": "{{service}}",
+          "range": true,
+          "interval": "1d",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 8,
+            "showPoints": "always",
+            "lineInterpolation": "linear"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true, "calcs": ["mean", "lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "id": 9,
+      "type": "table",
+      "title": "Algo Exceptions (detailed counts)",
+      "description": "Current exception counts for algo containers (Detection, Ctm, Gtm, DecisionEngine). Detailed breakdown by pool, service, and exception type.",
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 29 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "(cvs_exc_per_service{environment=~\"$server\", site_name=~\"$site_name\", pool_name=~\"$pool_name\", group=~\"$deploy_group\", exception_name!~\"NoneType|KeyboardInterrupt\", service=~\"Detection|Ctm|Gtm|DecisionEngine\"} and on(pool_name, site_name, environment) swimmer_count{environment=~\"$server\", pool_state=~\"$pool_state\", group=~\"$deploy_group\", under_maintenance=~\"$under_maintenance\"}) > 0",
+          "legendFormat": "{{site_name}} / {{pool_name}} / {{service}} ({{exception_name}})",
+          "instant": true,
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "custom": { "filterable": true } },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "Time" }, "properties": [{ "id": "custom.hidden", "value": true }] },
+          { "matcher": { "id": "byName", "options": "__name__" }, "properties": [{ "id": "custom.hidden", "value": true }] },
+          { "matcher": { "id": "byName", "options": "job" }, "properties": [{ "id": "custom.hidden", "value": true }] },
+          { "matcher": { "id": "byName", "options": "name" }, "properties": [{ "id": "custom.hidden", "value": true }] },
+          { "matcher": { "id": "byName", "options": "group" }, "properties": [{ "id": "custom.hidden", "value": true }] },
+          { "matcher": { "id": "byName", "options": "Value" }, "properties": [{ "id": "displayName", "value": "Count" }] }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [{ "displayName": "Count", "desc": true }, { "displayName": "site_name", "desc": false }, { "displayName": "pool_name", "desc": false }]
+      }
+    }
+  ]
+}

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -10,6 +10,7 @@ global:
 # Load and evaluate rules in this file every 'evaluation_interval' seconds.
 rule_files:
   - "alert.rules"
+  - "recording.rules"
 
 # A scrape configuration containing exactly one endpoint to scrape.
 scrape_configs:

--- a/prometheus/recording.rules
+++ b/prometheus/recording.rules
@@ -1,0 +1,10 @@
+groups:
+  - name: cvs_stability
+    rules:
+      # 1 when swimmer_count >= 0 and NOT in maintenance, absent during maintenance
+      - record: cvs:swimmer_valid:bool
+        expr: (swimmer_count >= bool 0) and on(pool_name, site_name, environment) (cvs_maintenance_mode == 0)
+
+      # 1 when swimmer_count < 0 and NOT in maintenance, 0 otherwise
+      - record: cvs:swimmer_incident:bool
+        expr: (swimmer_count * on(pool_name, site_name, environment) group_left() (cvs_maintenance_mode == bool 0)) < bool 0


### PR DESCRIPTION
## Summary
- Adds Prometheus recording rules (`recording.rules`) for CVS stability metrics
  - `cvs:swimmer_valid:bool`: 1 when swimmer_count >= 0 and NOT in maintenance, absent during maintenance
  - `cvs:swimmer_incident:bool`: 1 when swimmer_count < 0 and NOT in maintenance, 0 otherwise
- Updates `prometheus.yml` to load recording rules file
- Adds CVS Stability Metrics Grafana dashboard (`cvs_stability_metrics.json`)

## Why
The CVS Stability dashboard uses cross-metric joins (`swimmer_count × cvs_maintenance_mode`) inside subqueries. Each panel evaluation requires a join at every step, making long-range queries (30d) slow. More critically, the 5-minute subquery step misses brief incidents (<5m) that start and resolve between evaluation points.

Recording rules pre-compute the join at every 15s evaluation interval, so dashboard queries operate on a single pre-computed metric — no joins, full resolution, instant.

## Deployment
Already deployed to production Prometheus (`35.159.230.12`) with 30-day backfill running. Changes tracked here for future instance recreation.

## Test plan
- [x] Verified on staging Prometheus — recording rules produce correct data
- [x] Compared old (subquery) vs new (recording rule) dashboard results
- [x] Deployed to production and backfill started

🤖 Generated with [Claude Code](https://claude.com/claude-code)